### PR TITLE
modified text input in Saving window

### DIFF
--- a/include/saveTiffSmall.ahk
+++ b/include/saveTiffSmall.ahk
@@ -23,9 +23,8 @@ saveTiffSmall(outputDirName, currentName, channel, topWinId)
 	saveWinId := WinExist("A")
 
 	;Sequence to send filename
-	ControlFocus, Edit1, ahk_id %saveWinId%,
+	Send %outputFile%
 	Sleep 500
-	ControlSetText, Edit1, %outputFile%, ahk_id %saveWinId%, 
 
 	; Clicking Save
 	ControlFocus, Button2, ahk_id %saveWinId%,


### PR DESCRIPTION
The saving window in some OS seems doesn't recognize the saving path input with ControlSetText. replaced w/ send function and this seems work on most circumstances.